### PR TITLE
feat: add Dependabot configuration for Go and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly update schedules for Go modules and GitHub Actions

## Test plan
- [ ] Verify Dependabot PRs appear in the repository after merging

Co-Authored-By: Claude <noreply@anthropic.com>