### PR TITLE
chore: default version and date to "none"

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	version = "unknown"
+	version = "none"
 	commit  = "none"
-	date    = "unknown"
+	date    = "none"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Default `version` and `date` build vars to `"none"` for consistency with `commit`

## Test plan
- [ ] `go build` succeeds
- [ ] Running the binary without ldflags shows `none` for version/commit/date